### PR TITLE
Enable CORS for local frontend development on localhost:5173

### DIFF
--- a/UCMS_Implementation/UCMS/Program.cs
+++ b/UCMS_Implementation/UCMS/Program.cs
@@ -89,6 +89,16 @@ builder.Services.AddAuthentication(options =>{
         };
     });
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowLocalhost5173", policy =>
+    {
+        policy.WithOrigins("http://localhost:5173", "https://localhost:5173")
+              .AllowAnyHeader()
+              .AllowAnyMethod()
+              .AllowCredentials();
+    });
+});
 
 // builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 
@@ -110,6 +120,7 @@ app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 // app.UseRouting();
 app.UseHttpsRedirection();
+app.UseCors("AllowLocalhost5173");
 app.UseAuthentication();
 app.UseMiddleware<AuthenticationMiddleware>();
 app.UseAuthorization();


### PR DESCRIPTION
This PR adds a CORS policy named AllowLocalhost5173 to allow frontend requests from http://localhost:5173 and https://localhost:5173.
It supports all headers, methods, and allows credentials to enable proper integration during local development.